### PR TITLE
Fix Empty Records in Featured Products

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,4 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # development dependencies will be added by default to the :development group.
 gemspec
 
-gem 'bundler-audit'
-gem 'listen'
-
 gem 'workarea-api', '>= 4.x'

--- a/app/view_models/workarea/admin/featured_browse_option_products_view_model.rb
+++ b/app/view_models/workarea/admin/featured_browse_option_products_view_model.rb
@@ -16,6 +16,8 @@ module Workarea
                 tmp.browse_option => option&.optionize
               )
             end
+
+            results.compact
           end
       end
     end

--- a/test/integration/workarea/admin/browse_option_featured_products_integration_test.rb
+++ b/test/integration/workarea/admin/browse_option_featured_products_integration_test.rb
@@ -40,6 +40,22 @@ module Workarea
 
         assert_equal([], category.reload.product_ids)
       end
+
+      def test_delete_featured_products
+        product = create_product
+        category = create_category(product_ids: [product.id])
+
+        get admin.catalog_category_path(category)
+
+        assert(response.success?)
+
+        assert(product.destroy!)
+
+        # ActionView::Template::Error: undefined method `primary_image' for nil:NilClass
+        get admin.catalog_category_path(category)
+
+        assert(response.success?)
+      end
     end
   end
 end


### PR DESCRIPTION
When iterating over the `#featured_products` for a given category (or
anything else that can accept featured product IDs), ensure that there are
no `nil` records that are returned back by calling `#compact` on the final
result. This addresses an issue whereby deleting a product that was
featured in a category causes an error in admin when attempting to call
`#product_image` on `nil`.

Fixes #1