### PR TITLE
Update cache_key.decorator

### DIFF
--- a/app/view_models/workarea/storefront/product_view_model/cache_key.decorator
+++ b/app/view_models/workarea/storefront/product_view_model/cache_key.decorator
@@ -4,9 +4,9 @@ module Workarea
 
     def option_parts
       option = @product.browse_option
-      return super unless option.present? && @options[option].present?
+      return super unless option.present? && @options['option'].present?
 
-      super.unshift(@options[option])
+      super.unshift(@options['option'].optionize)
     end
   end
 end

--- a/app/view_models/workarea/storefront/product_view_model/cache_key.decorator
+++ b/app/view_models/workarea/storefront/product_view_model/cache_key.decorator
@@ -4,9 +4,10 @@ module Workarea
 
     def option_parts
       option = @product.browse_option
-      return super unless option.present? && @options['option'].present?
+      value = @options[option].presence || @options['option'].presence
+      return super unless option.present? && value.present?
 
-      super.unshift(@options['option'].optionize)
+      super.unshift(value.optionize)
     end
   end
 end

--- a/test/system/workarea/admin/bulk_action_product_edit_browse_option_test.rb
+++ b/test/system/workarea/admin/bulk_action_product_edit_browse_option_test.rb
@@ -21,7 +21,7 @@ module Workarea
         select 'Color', from: 'bulk_action[settings][browse_option]'
 
         click_button t('workarea.admin.bulk_action_product_edits.edit.review_changes')
-        assert(page.has_content?('Browse Option: Color'))
+        assert(page.has_content?('Browse Option Color'))
         click_button t('workarea.admin.bulk_action_product_edits.review.save_and_finish')
         assert(page.has_content?('Your product edits are being processed'))
 

--- a/test/view_models/workarea/storefront/browse_option_product_view_model_test.rb
+++ b/test/view_models/workarea/storefront/browse_option_product_view_model_test.rb
@@ -35,6 +35,15 @@ module Workarea
 
         view_model = ProductViewModel.new(cached_product, color: 'red')
         assert_match(/red/, view_model.cache_key)
+
+        view_model = ProductViewModel.new(cached_product, option: 'red')
+        assert_match(/red/, view_model.cache_key)
+
+        view_model = ProductViewModel.new(cached_product, color: 'red', option: '')
+        assert_match(/red/, view_model.cache_key)
+
+        view_model = ProductViewModel.new(cached_product, color: '', option: 'red')
+        assert_match(/red/, view_model.cache_key)
       end
 
       def test_primary_image


### PR DESCRIPTION
Base on what I'm reading here: https://github.com/workarea-commerce/workarea-browse-option/blob/master/app/models/workarea/search/storefront/product_option.rb

and some experimentation in a shell:
```
irb(main):021:0> p.options['option']
=> "Dusty Blue"
irb(main):022:0> p.browse
p.browse_link_options   p.browse_option         p.browse_options        p.browse_swatch_option  p.browser_title
irb(main):022:0> p.browse_option
=> "color"
irb(main):023:0> p.options[p.browse_option]
=> nil
```

This looks like it needs to be updated