### PR TITLE
Restore Functionality for Explicit Options Passing

### DIFF
--- a/app/view_models/workarea/storefront/product_view_model/cache_key.decorator
+++ b/app/view_models/workarea/storefront/product_view_model/cache_key.decorator
@@ -4,9 +4,11 @@ module Workarea
 
     def option_parts
       option = @product.browse_option
-      return super unless option.present? && @options['option'].present?
+      value = @options['option'].presence || @options[option].presence
 
-      super.unshift(@options['option'].optionize)
+      return super unless option.present? && value.present?
+
+      super.unshift(value.optionize)
     end
   end
 end

--- a/test/view_models/workarea/storefront/browse_option_product_view_model_test.rb
+++ b/test/view_models/workarea/storefront/browse_option_product_view_model_test.rb
@@ -36,6 +36,9 @@ module Workarea
 
         view_model = ProductViewModel.new(cached_product, color: 'red')
         assert_match(/red/, view_model.cache_key)
+
+        view_model = ProductViewModel.new(cached_product, option: 'red')
+        assert_match(/red/, view_model.cache_key)
       end
 
       def test_primary_image


### PR DESCRIPTION
Sometimes, an option named "option" will be passed into the product view
model that indicates what should be included in the cache key, and other
times it will be the actual name of the option, like "color". Ensure
that both variants are supported in the `CacheKey#option_parts` for
product view models.